### PR TITLE
fix: improved detection of all peripherals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"displayName": "Homebridge Switchmate Switch",
 	"name": "homebridge-switchmate-switch",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "A homebridge plugin for Switchmate switch",
 	"license": "MIT",
 	"repository": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -87,10 +87,7 @@ export class SwitchmateSwitchPlatform implements DynamicPlatformPlugin {
 			if (!that.discoveredAll) {
 				that.log.debug('we have not discovered all configured devices, restarting scan...');
 				noble.removeAllListeners('discover');
-				noble.on('discover', discoverPeripharels);
-				noble.startScanningAsync([POWER_SERVICE_UUID], false).catch((error) => {
-					that.log.error(`failed to start noble scanning: ${error}`);
-				});
+				startDiscovery();
 			}
 		};
 

--- a/src/switchmateDevice.ts
+++ b/src/switchmateDevice.ts
@@ -15,7 +15,7 @@ const POWER_SERVICE_UUID = 'a22bd383ebdd49acb2e740eb55f5d0ab';
 const POWER_CURRENT_CHARACTERISTIC_UUID = 'a22b0070ebdd49acb2e740eb55f5d0ab';
 const POWER_TARGET_CHARACTERISTIC_UUID = 'a22b0090ebdd49acb2e740eb55f5d0ab';
 // timeout
-const DEFAULT_TIMEOUT = 10000; // 10s
+const DEFAULT_TIMEOUT = 15000; // 15s
 
 export interface SwitchmateDeviceInformation {
 	manufacturer: string;


### PR DESCRIPTION
When the plugin scans for a new device, it configures a handler for Noble's scanStop event. However, the handler will only fire once, causing devices to not detect while using the plugin. This quick fix reuses your startDiscovery() function which will set the scanStop event handler again if not all devices are found.